### PR TITLE
Allow content to utilize more screen width

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -60,3 +60,7 @@
 .codehilite .vg { color: #bb60d5 } /* Name.Variable.Global */
 .codehilite .vi { color: #bb60d5 } /* Name.Variable.Instance */
 .codehilite .il { color: #40a070 } /* Literal.Number.Integer.Long */
+
+.wy-nav-content {
+    max-width: 90%;
+}

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,3 +1,9 @@
+.codehilite{
+          width:100%;
+          height: auto;
+          overflow: auto;
+        }
+
 .codehilite .hll { background-color: #ffffcc }
 .codehilite  { background: #f0f0f0; }
 .codehilite .c { color: #60a0b0; font-style: italic } /* Comment */


### PR DESCRIPTION
Let's flesh out details for the exact number of pixels/percentages here. For an idea of how this looks, you can go [here](https://opensciencegrid.github.io/technology/release/cut-sw-release/), open your browser's dev console (F12 on firefox), go to the style editor, and add the following to `extra.css`:

```
.wy-nav-content {
    max-width: 90%;
}
```