### PR TITLE
Change instructions to use twiki-converter docker image

### DIFF
--- a/docs/software/markdown-migration.md
+++ b/docs/software/markdown-migration.md
@@ -3,68 +3,109 @@ Migrating to Markdown
 
 As part of the TWiki retirement (the read-only target date of Oct 1, 2017, with a shutdown date in 2018), we will need to convert the OSG Software and Release3 docs from TWiki syntax to [Markdown](https://guides.github.com/features/mastering-markdown/). The following document outlines the conversion process and conventions.
 
-Choosing document locations and names
--------------------------------------
+Requirements
+------------
 
-`SoftwareTeam` documents should go into the [technology github repo](https://opensciencegrid.github.io/technology/) and `Release3` documents should go into the [docs github repo](https://opensciencegrid.github.io/docs/). Document file names should be lowercase, `-` delimited, and descriptive but concise, e.g. `markdown-migration.md` or `cutting-release.md`
+To perform a document migration, you will need the following tools and accounts:
 
-Archiving the TWiki document
+- `git` and a GitHub account
+- A host with a running docker service
+- `sudo` or membership in the `docker` group
+
+If you cannot install the above tools locally, they are available on `osghost`. Speak with Brian L for access.
+
+Preparing the git repository
 ----------------------------
 
-Save the raw TWiki file into the `docs/archive/` folder of your local git repository:
+First you will need to choose which git repoository you will be working with:
+
+| If you are converting a document from... | Use this github repository... |
+| :--------------------------------------- | :---------------------------- |
+| SoftwareTeam | [technology](https://www.github.com/opensciencegrid/technology/) |
+| Release3 | [docs](https://www.github.com/opensciencegrid/docs/) |
+
+Once you've chosen the target repository for your document, prepare your local repository:
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) the repository
+2. Clone a local repository:
+
+        :::console
+        [user@client ~ ] $ git clone git:github.com/<GITHUB USERNAME>/<REPOSITORY>.git
+
+3. Add `opensciencegrid/technology` as the upstream remote repository for merging upstream changes:
+
+        :::console
+        [user@client ~ ] $ git remote add upstream https://www.github.com/opensciencegrid/<REPOSITORY>.git
+
+4. Create a branch for the document you plan to convert:
+
+        :::console
+        [user@client ~ ] $ git branch <BRANCH NAME> master
+
+Using the twiki-converter docker image
+--------------------------------------
+
+The twiki-converter docker image can be used to preview the document tree via a [mkdocs](http://www.mkdocs.org/#getting-started) development server, archive TWiki documents, and convert documents to Markdown via [pandoc](http://pandoc.org/). The image is available on `osghost`, otherwise, follow the instructions [here](https://github.com/brianhlin/docker-twiki-converter) to build it locally. 
+
+### Preview the document tree ###
+
+When starting a twiki-converter docker container, it expects your local github repository to be mounted in `/source` so that any changes made to the repository are reflected in the mkdocs development server. To start a docker container based off of the twiki-converter docker image:
+
+1. Create a container from the image with the following command:
+
+        :::console
+        [user@client ~ ] $ docker run -d -v <PATH TO LOCAL GITHUB REPO>:/source -p 8000 twiki
+    The above command should return the container ID, which will be used in subsequent commands. 
+
+    !!! note
+        If the docker container exits immediately, remove the `-d` option for details. If you see permission denied errors, you may need to disable SELinux or put it in permissive mode.
+
+2. To find the port that your development server is lisetning on, use the container ID (you should only need the first few chars of the ID) returned from the previous command:
+
+        :::console
+        [user@client ~ ] $ docker port <CONTAINER ID>
+
+3. Access the development server in your browser via `http://osghost.chtc.wisc.edu:<PORT>` or `localhost:<PORT>` for containers run on `osghost` or locally, respectively. `osghost` has a restrictive firewall so if you have issues accessing your container from outside of the UW-Madison campus, use an SSH tunnel to map the `osghost` port to a local port.
+
+### Convert documents ###
+
+The docker image contains a convenience script, `convert-twiki` for saving archives and converting them to Markdown. To run the script in a running container, run the following command:
 
 ```console
-[user@client ~] $ curl '<TWIKI URL>?raw=text' | iconv -f windows-1252 > docs/archive/<TWIKI TITLE>
+[user@client ~ ] $ docker exec <CONTAINER ID> convert-twiki <TWIKI URL>
 ```
 
-For example, to archive https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SHA2Compliance:
+Where <CONTAINER ID> is the docker container ID and <TWIKI URL> is the link to the TWiki document that you want to convert, e.g. [https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/SoftwareDevelopmentProcess](https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/SoftwareDevelopmentProcess). This will result in an archive of the twiki doc, `docs/archive/SoftwareDevelopmentProcess`, in your local repo and a converted copy, `SoftwareDevelopmentProcess`, placed into the root of your local github repository. 
 
-```console
-$ curl 'https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SHA2Compliance?raw=text' | iconv -f windows-1252 > docs/archive/SHA2Compliance
-```
+!!! warning
+    If the above command does not complete quickly, it means that Pandoc is having an issue with a specific section of the document. See [Troubleshooting conversion](#troubleshooting-conversion) for next steps.
 
-Initial conversion with Pandoc
-------------------------------
+To see the converted document in your browser:
 
-[Pandoc](http://pandoc.org/) is a tool that's useful for automated conversion of markdown languages. [Once installed](http://pandoc.org/installing.html) (alternatively, run pandoc [via docker](#using-docker)), run the following command to convert TWiki to Markdown:
+1. Rename and move the converted document into the appropriate folder in `docs/`. 
+    - Document file names should be lowercase, `-` delimited, and descriptive but concise, e.g. `markdown-migration.md` or `cutting-release.md`
+    - It's not important to get the name/location correct on the first try as this can be discussed in the pull request
+2. Add the document to the `pages:` section of `mkdocs.yml` in [title case](http://titlecase.com/), e.g. `- Migrating Documents to Markdown: 'software/markdown-migration.md'`
+3. Refresh the document tree in your browser
 
-```console
-$ pandoc -f twiki -t markdown_github <TWIKI FILE> > <MARKDOWN FILE>
-```
+#### Troubleshooting conversion ####
 
-Where `<TWIKI FILE>` is the path to initial document in raw TWiki and `<MARKDOWN FILE>` is the path to the resulting document in GitHub Markdown.
+Pandoc sometimes has issues converting documents and requires manual intervention by removing whichever section is causing issues in the conversion.
 
-!!! note
-    If you don't see output from the above command quickly, it means that Pandoc is having an issue with a specific section of the document. Stop the command (or docker container), find and temporarily remove the offending section, convert the remainder of the document with Pandoc, and manually convert the offending section.
+1. Copy the archive of the document into the root of your git repository
+2. Kill the process in the docker container:
 
-### Using docker ###
+        :::console
+        [user@client ~ ] $ docker exec <CONTAINER ID> pkill -9 pandoc
 
-The `pandoc` library is written in Haskell and is frequently updated, meaning it may be unavailable on your distribution of choice - or too old.  If you cannot install `pandoc` but have access to docker, you can run the following command:
+3. Remove a section from the copy of the archive to find the problematic section (recommendation: use a binary search strategy)
+4. Run pandoc manually:
 
-```bash
-docker run -v `pwd`:/source jagregory/pandoc -f twiki -t markdown_github <TWIKI FILE> > <MARKDOWN FILE>
-```
+        :::console
+        [user@client ~ ] $ docker exec <CONTAINER ID> pandoc -f twiki -t markdown_github <ARCHIVE COPY> > <MARKDOWN FILE>
 
-For example, to do a Docker-based conversion of the document at https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SHA2Compliance, one would do:
-
-```bash
-$ mkdir -p docs/archive docs/projects
-$ curl 'https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SHA2Compliance?raw=text' | iconv -f windows-1252 > docs/archive/SHA2Compliance
-$ docker run -v `pwd`/docs/:/source jagregory/pandoc -f twiki -t markdown_github /source/archive/SHA2Compliance > docs/projects/sha2-support.md
-```
-
-We have found some cases where the Docker version of `pandoc` handles Twiki syntax better than the EPEL one; YMMV.  Testing also shows that the conversion process is only about 80% accurate and each document will require a few minutes of manual touch-up.  The above example required no formatting changes.
-
-Previewing your document(s) with Mkdocs
----------------------------------------
-
-[Mkdocs](http://www.mkdocs.org/) has a development mode that can be used to preview documents as you work on them and is available via package manager or `pip`. [Once installed](http://www.mkdocs.org/#installation), add your document(s) to the `pages` section of `mkdocs.yml` and launch the mkdocs server with the following command from the dir containing `mkdocs.yml`:
-
-```console
-$ PYTHONPATH=src/ mkdocs serve
-```
-
-Access the server at `http://127.0.0.1:8000` and navigate to the document you're working on. It's useful to open the original TWiki doc in an adjacent tab or window to quickly compare the two.
+5. Repeat steps 2-4 until you've narrowed down the problematic section
+6. Manually convert the offending section
 
 Things to watch out for
 -----------------------
@@ -77,8 +118,8 @@ If the broken link is:
 
 1. For a document that has already been migrated to GitHub, update it to point at the new location.
 2. For a document that not been migrated to GitHub, consult the documentation spreadsheet (contact Brian L for access):
-   a. If the link is targeted for archival, remove the link if it makes sense. If you're unsure, be sure to mention it in your final pull request
-   b. If the link is not targeted for archival, link directly to the TWiki page.
+    - If the link is targeted for archival, remove the link if it makes sense. If you're unsure, be sure to mention it in your final pull request
+    - If the link is not targeted for archival, link directly to the TWiki page.
 
 ### Broken command blocks and file snippets ###
 
@@ -169,26 +210,24 @@ The above block is rendered below as an example.
 
 If you see any other obvious errors (e.g., links to gratia web), feel free to correct them while you're editing the doc *iff* the changes take less than ~15 minutes. This isn't a renovation project!
 
-Making the pull request
------------------------
+Submitting the pull request
+---------------------------
 
-1. Create a branch based off of master
-2. Add page to [mkdocs.yml](../../mkdocs.yml) in [title case](http://titlecase.com/), e.g. `Migrating Documents to Markdown`
-3. `git add` the archived raw TWiki and the converted Markdown document(s)
-4. `git commit` your changes and `git push` to your GH repo
-5. Make PR containing the following tasks in the body:
+1. `git add` the archived raw TWiki, the converted Markdown document(s), and `mkdocs.yml`
+2. `git commit` your changes and `git push` to your GitHub repo
+3. Submit a pull request containing the following tasks in the body:
 
         <LINK TO TWIKI DOCUMENT>
 
         - [ ] Enter date into "Migrated" column of google sheet
         - [ ] Add migration header to TWiki document
 
-See an example pull request [here](https://github.com/opensciencegrid/technology/pull/82).
+See an example pull request [here](https://github.com/opensciencegrid/technology/pull/98).
 
-Adding a header to the TWiki document
--------------------------------------
+After the pull request
+----------------------
 
-After completing the migration of a document, replace the contents of TWiki document with the following header, linking to the location of the migrated document:
+After the pull request is merged, replace the contents of TWiki document with the div, linking to the location of the migrated document:
 
 ```
 <div style="border: 1px solid black; margin: 1em 0; padding: 1em; background-color: #FFDDDD; font-weight: 600;">
@@ -203,23 +242,24 @@ At the end of year (2017), the TWiki will be retired in favor of !GitHub. You ca
 </div>
 ```
 
-Once the header has been added, go back to your pull request and mark that task as complete:
+Once the div has been added, update the spreadsheet and go back to your pull request and mark your tasks as complete:
 
-    - [X] Add migration header to TWiki document
-
+```
+- [X] Enter date into "Migrated" column of google sheet
+- [X] Add migration header to TWiki document
+```
 Currently, we do not recommend changing backlinks (links on other twiki pages that refer to the Twiki page you are migrating) to point at the new GitHub URL.  This is to provide a simple reminder to users that the migration will occur, and also is likely low priority regardless as all pages will eventually migrate to GitHub.  This advice may change in the future as we gain experience with this transition.
 
 Reviewing pull requests
 -----------------------
 
-To review pull requests, `cd` into the dir containing your git repository, check out the requester's branch, and start a local `mkdocs` server. Here's an example checking out Brian's `cut-sw-release` branch of the technology repository:
+To review pull requests, `cd` into the dir containing your git repository and check out the requester's branch, which the twiki-converter container should automatically notice. Here's an example checking out Brian's `cut-sw-release` branch of the technology repository:
 
 ```console
 # Add the requester's repo as a remote if you haven't already
 [user@client ~ ] $ git remote add blin https://www.github.com/brianhlin/technology.git
 [user@client ~ ] $ git fetch --all
 [user@client ~ ] $ git checkout blin/cut-sw-release
-[user@client ~ ] $ PYTHONPATH=src/ mkdocs serve
 ```
 
-Access the server at `http://127.0.0.1:8000` and navigate to the document in the request.
+Refresh your browser and navigate to the document in the request.

--- a/docs/software/markdown-migration.md
+++ b/docs/software/markdown-migration.md
@@ -194,17 +194,29 @@ There are 12 spaces and 8 spaces in front of the command block and text associat
 
 ### Notes ###
 
-To catch the user's attention for important items or pitfalls, we used `%NOTE%` TWiki macros, these can be replaced with admonition-style notes:
+To catch the user's attention for important items or pitfalls, we used `%NOTE%` TWiki macros, these can be replaced with admonition-style notes and warnings:
 
 ```
 !!! note
     things to note
 ```
 
-The above block is rendered below as an example.
+or
+
+```
+!!! warning
+    if a user doesn't do this thing, bad stuff will happen
+```
+
+The above blocks are rendered below as an example.
 
 !!! note
     things to note
+
+and
+
+!!! warning
+    if a user doesn't do this thing, bad stuff will happen
 
 ### Obvious errors ###
 

--- a/docs/software/markdown-migration.md
+++ b/docs/software/markdown-migration.md
@@ -198,13 +198,13 @@ To catch the user's attention for important items or pitfalls, we used `%NOTE%` 
 
 ```
 !!! note
-    # things to note
+    things to note
 ```
 
 The above block is rendered below as an example.
 
 !!! note
-    # things to note
+    things to note
 
 ### Obvious errors ###
 


### PR DESCRIPTION
- People don't have to bother with installing pandoc/mkdocs if they don't want to 
- We can add automatic conversions to the `convert-twiki` script for common issues that pandoc misses (ToC, console prompts)