### PR TITLE
Fix monospace font so it's the same height as the surrounding text

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -70,3 +70,8 @@
 .wy-nav-content {
     max-width: 90%;
 }
+
+code, tt {
+    font-size: 100%;
+}
+


### PR DESCRIPTION
For in-line monospaced text (i.e. between single backticks), the monospaced font is shorter than the surrounding text, making it uglier. This CSS tweak fixes that issue. @brianhlin, @bbockelm, @djw8605, what do you think about this change?