### PR TITLE
Converted WritingDocumentation => documentation/writing-documentation.md

### DIFF
--- a/docs/archive/WritingDocumentation
+++ b/docs/archive/WritingDocumentation
@@ -1,0 +1,16 @@
+---+ Tips for Writing Software Documentation
+
+---++ Writing Procedural (Step-by-Step) Instructions
+
+   * <p>Title the procedure with the user goal, usually starting with a gerund; e.g.:</p>\
+      <p><strong>Installing the Frobnosticator</strong></p>
+   * <p>Number all steps (as opposed to using bullets)</p>
+   * <p>List steps in order in which they are performed</p>
+   * <p>Each step should begin with a single-line instruction in plain English, in command form; e.g.:</p>\
+      <p>3. Make sure that the Frobnosticator configuration file is world-writable</p>
+   * <p>If the means of carrying out the instruction is unclear or complex, include clarification, ideally in the form of a working example; e.g.:</p>\
+      <pre class="command">chmod a+x /usr/share/frobnosticator/frob.conf</pre>
+   * <p>Put clarifying information in separate paragraphs within the step</p>
+   * <p>Put critical information about the *whole* procedure in one or more paragraphs before the numbered steps</p>
+   * <p>Put supplemental information about the *whole* procedure in one or more paragraphs after the numbered steps</p>
+   * <p>Avoid pronouns when writing technical articles or documentation e.g., =install foo= rather than =install it=.</p>

--- a/docs/documentation/writing-documentation.md
+++ b/docs/documentation/writing-documentation.md
@@ -1,0 +1,29 @@
+Tips for Writing Software Documentation
+=======================================
+
+Writing Procedural (Step-by-Step) Instructions
+----------------------------------------------
+
+- Title the procedure with the user goal, usually starting with a gerund; e.g.:
+
+    **Installing the Frobnosticator**
+
+- Number all steps (as opposed to using bullets)
+
+- List steps in order in which they are performed
+
+- Each step should begin with a single-line instruction in plain English, in command form; e.g.:
+    3. Make sure that the Frobnosticator configuration file is world-writable
+
+- If the means of carrying out the instruction is unclear or complex, include clarification, ideally in the form of a working example; e.g.:
+  ```
+  chmod a+x /usr/share/frobnosticator/frob.conf
+  ```
+
+- Put clarifying information in separate paragraphs within the step
+
+- Put critical information about the **whole** procedure in one or more paragraphs before the numbered steps
+
+- Put supplemental information about the **whole** procedure in one or more paragraphs after the numbered steps
+
+- Avoid pronouns when writing technical articles or documentation e.g., `install foo` rather than `install it`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,8 @@ pages:
     - Koji-Hub Setup: 'infrastructure/koji-hub-setup.md'
     - Koji Infrastructure Overview: 'infrastructure/koji-inf-overview.md'
     - Koji Policy Writing: 'infrastructure/koji-policy-writing.md'
+  - Documentation:
+    - Writing Documentation: 'documentation/writing-documentation.md'
   - Historical Information:
     - Koji Initial Install: 'infrastructure/koji-initial-install.md'
   - Historical Transitions:


### PR DESCRIPTION
Looks lousy, but the content is there. GEFGW.

https://twiki.opensciencegrid.org/bin/view/SoftwareTeam/WritingDocumentation

- [ ] Enter date into "Migrated" column of spreadsheet
- [ ] Add migration header to TWiki document
