### PR TITLE
Make code-block margins same as print blocks

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -2,6 +2,7 @@
           width:100%;
           height: auto;
           overflow: auto;
+          margin-bottom: 24px;
         }
 
 .codehilite .hll { background-color: #ffffcc }


### PR DESCRIPTION
The current theme adds a 24px margin to the bottom of all styles *except* for code-highlight blocks.  This makes for an awkward, inconsistent lack-of-space below pre-formatted text.

This has the codehilite class the same as the rest of the documents.