### PR TITLE
Fix filename refs in VM test section

### DIFF
--- a/docs/release/cut-sw-release.md
+++ b/docs/release/cut-sw-release.md
@@ -77,7 +77,7 @@ To test pre-release, you will be kicking off a manual VM universe test run from 
         [user@client ~] $ osg-run-tests 'Testing OSG pre-release'
 
 3.  `cd` into the directory specified in the output of the previous command
-4.  `cd` into `parameters.d` and remove all files within it except for `osg33-el6.yaml` and `osg33-el7.yaml`
+4.  `cd` into `parameters.d` and remove all files within it except for `osg33.yaml` and `osg34.yaml`
 5.  Edit `osg33.yaml` so that it reads:
 
         platforms:


### PR DESCRIPTION
The files names in the text don't match (osg33-el6.yaml, osg33-el7.yaml  vs osg33.yaml, osg34.yaml).  