### PR TITLE
 Updating theme and moving meetings into sub area

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,7 @@ site_name: OSG Technology Area
 site_url: https://opensciencegrid.github.io/technology/
 repo_url: https://github.com/opensciencegrid/technology/
 theme:
-  name: readthedocs
-  custom_dir: osgthedocs
+  name: material
 
 extra_css:
   - css/extra.css
@@ -63,42 +62,43 @@ pages:
     - Koji Initial Install: 'infrastructure/koji-initial-install.md'
   - Historical Transitions:
     - 'SHA-2 Support': 'projects/sha2-support.md'
-  - February 27, 2017: 'meetings/2017/TechArea20170227.md'
-  - April 17, 2017: 'meetings/2017/TechArea20170417.md'
-  - April 24, 2017: 'meetings/2017/TechArea20170424.md'
-  - May 1, 2017: 'meetings/2017/TechArea20170501.md'
-  - May 8, 2017: 'meetings/2017/TechArea20170508.md'
-  - May 15, 2017: 'meetings/2017/TechArea20170515.md'
-  - May 22, 2017: 'meetings/2017/TechArea20170522.md'
-  - May 30, 2017: 'meetings/2017/TechArea20170530.md'
-  - June 6, 2017: 'meetings/2017/TechArea20170605.md'
-  - June 12, 2017: 'meetings/2017/TechArea20170612.md'
-  - June 19, 2017: 'meetings/2017/TechArea20170619.md'
-  - June 26, 2017: 'meetings/2017/TechArea20170626.md'
-  - July 3, 2017: 'meetings/2017/TechArea20170703.md'
-  - July 10, 2017: 'meetings/2017/TechArea20170710.md'
-  - July 17, 2017: 'meetings/2017/TechArea20170717.md'
-  - July 24, 2017: 'meetings/2017/TechArea20170724.md'
-  - July 31, 2017: 'meetings/2017/TechArea20170731.md'
-  - August 7, 2017: 'meetings/2017/TechArea20170807.md'
-  - August 14, 2017: 'meetings/2017/TechArea20170814.md'
-  - August 28, 2017: 'meetings/2017/TechArea20170828.md'
-  - September 5, 2017: 'meetings/2017/TechArea20170905.md'
-  - September 11, 2017: 'meetings/2017/TechArea20170911.md'
-  - September 18, 2017: 'meetings/2017/TechArea20170918.md'
-  - September 25, 2017: 'meetings/2017/TechArea20170925.md'
-  - October 2, 2017: 'meetings/2017/TechArea20171002.md'
-  - October 9, 2017: 'meetings/2017/TechArea20171009.md'
-  - October 16, 2017: 'meetings/2017/TechArea20171016.md'
-  - October 23, 2017: 'meetings/2017/TechArea20171023.md'
-  - October 30, 2017: 'meetings/2017/TechArea20171030.md'
-  - November 6, 2017: 'meetings/2017/TechArea20171106.md'
-  - November 13, 2017: 'meetings/2017/TechArea20171113.md'
-  - November 20, 2017: 'meetings/2017/TechArea20171120.md'
-  - November 27, 2017: 'meetings/2017/TechArea20171127.md'
-  - December 4, 2017: 'meetings/2017/TechArea20171204.md'
-  - December 11, 2017: 'meetings/2017/TechArea20171211.md'
-
+  - Meetings:
+    - February 27, 2017: 'meetings/2017/TechArea20170227.md'
+    - April 17, 2017: 'meetings/2017/TechArea20170417.md'
+    - April 24, 2017: 'meetings/2017/TechArea20170424.md'
+    - May 1, 2017: 'meetings/2017/TechArea20170501.md'
+    - May 8, 2017: 'meetings/2017/TechArea20170508.md'
+    - May 15, 2017: 'meetings/2017/TechArea20170515.md'
+    - May 22, 2017: 'meetings/2017/TechArea20170522.md'
+    - May 30, 2017: 'meetings/2017/TechArea20170530.md'
+    - June 6, 2017: 'meetings/2017/TechArea20170605.md'
+    - June 12, 2017: 'meetings/2017/TechArea20170612.md'
+    - June 19, 2017: 'meetings/2017/TechArea20170619.md'
+    - June 26, 2017: 'meetings/2017/TechArea20170626.md'
+    - July 3, 2017: 'meetings/2017/TechArea20170703.md'
+    - July 10, 2017: 'meetings/2017/TechArea20170710.md'
+    - July 17, 2017: 'meetings/2017/TechArea20170717.md'
+    - July 24, 2017: 'meetings/2017/TechArea20170724.md'
+    - July 31, 2017: 'meetings/2017/TechArea20170731.md'
+    - August 7, 2017: 'meetings/2017/TechArea20170807.md'
+    - August 14, 2017: 'meetings/2017/TechArea20170814.md'
+    - August 28, 2017: 'meetings/2017/TechArea20170828.md'
+    - September 5, 2017: 'meetings/2017/TechArea20170905.md'
+    - September 11, 2017: 'meetings/2017/TechArea20170911.md'
+    - September 18, 2017: 'meetings/2017/TechArea20170918.md'
+    - September 25, 2017: 'meetings/2017/TechArea20170925.md'
+    - October 2, 2017: 'meetings/2017/TechArea20171002.md'
+    - October 9, 2017: 'meetings/2017/TechArea20171009.md'
+    - October 16, 2017: 'meetings/2017/TechArea20171016.md'
+    - October 23, 2017: 'meetings/2017/TechArea20171023.md'
+    - October 30, 2017: 'meetings/2017/TechArea20171030.md'
+    - November 6, 2017: 'meetings/2017/TechArea20171106.md'
+    - November 13, 2017: 'meetings/2017/TechArea20171113.md'
+    - November 20, 2017: 'meetings/2017/TechArea20171120.md'
+    - November 27, 2017: 'meetings/2017/TechArea20171127.md'
+    - December 4, 2017: 'meetings/2017/TechArea20171204.md'
+    - December 11, 2017: 'meetings/2017/TechArea20171211.md'
+  
 markdown_extensions:
   - admonition
   - codehilite


### PR DESCRIPTION
Copied what BrianL did with release notes in the docs area.
Moved the meeting nodes under an expandable dropdown in the left
nav bar.