### PR TITLE
Fix the flexible release doc link

### DIFF
--- a/docs/policy/community-testing.md
+++ b/docs/policy/community-testing.md
@@ -7,7 +7,7 @@ The community of OSG resource providers has a vested interest in the quality and
 We would like to notify our stakeholders of software updates as soon as they are designated as "Ready for Testing" by
 the Software Team.
 Direct engagement with the entire community would allow for feedback from a broader array of interested parties.
-Combined with our [flexible release model](/release/flexible-release-model), we hope to further improve the turnaround
+Combined with our [flexible release model](/docs/policy/flexible-release-model.md), we hope to further improve the turnaround
 time of new features and bug fixes.
 
 Implementation


### PR DESCRIPTION
For review when unpublished. We'll need to change the link
`/policy/flexible-release-model` when we decide to publish it today.