### PR TITLE
Disable auto highlight

### DIFF
--- a/docs/documentation/style-guide.md
+++ b/docs/documentation/style-guide.md
@@ -194,11 +194,13 @@ or
 
 The above blocks are rendered below as an example.
 
-!!! note things to note
+!!! note
+    things to note
 
 and
 
-!!! warning if a user doesn't do this thing, bad stuff will happen
+!!! warning
+    if a user doesn't do this thing, bad stuff will happen
 
 For a full list of admonition styles, see the documentation
 [here](https://squidfunk.github.io/mkdocs-material/extensions/admonition/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,6 @@ pages:
 markdown_extensions:
   - admonition
   - codehilite
-  - toc:
-      permalink: True
+  - toc(permalink=true):
   - osg_markdown.colors
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,7 @@ pages:
 
 markdown_extensions:
   - admonition
-  - codehilite
+  - codehilite(guess_lang=false)
   - toc(permalink=true):
   - osg_markdown.colors
 


### PR DESCRIPTION
With the default `guess_lang=true`:

![before](https://user-images.githubusercontent.com/390105/60904306-723d5080-a238-11e9-8f21-50da09d22c5e.png)

With `guess_lang=false`:

![after](https://user-images.githubusercontent.com/390105/60904326-7d907c00-a238-11e9-9a21-789e68745bbf.png)
