### PR TITLE
Use koji.opensciencegrid.org instead of koji.chtc.wisc.edu

### DIFF
--- a/docs/software/koji-workflow.md
+++ b/docs/software/koji-workflow.md
@@ -1,7 +1,7 @@
 Koji Workflow
 =============
 
-This covers the basics of using and understanding the [OSG Koji](https://koji.chtc.wisc.edu/koji) instance. It is meant primarily for OSG Software team members who need to interact with the service.
+This covers the basics of using and understanding the [OSG Koji](https://koji.opensciencegrid.org/koji) instance. It is meant primarily for OSG Software team members who need to interact with the service.
 
 Terminology
 -----------
@@ -78,7 +78,7 @@ Both pieces of software are available from the osg repositories. `osg-build` may
 
 You will be using your grid certificate to log in. Email a Koji admin the DN of your certificate, and we will set up a Koji account with the appropriate permissions.
 
-If you are switching certificate providers, you will need to email a Koji admin with your new DN. You will also need to clear your browser cookies and cache for `https://koji.chtc.wisc.edu` before trying to use the Koji web interface again. If your CN has changed, you will not be able to use your old certificate.
+If you are switching certificate providers, you will need to email a Koji admin with your new DN. You will also need to clear your browser cookies and cache for `https://koji.opensciencegrid.org` before trying to use the Koji web interface again. If your CN has changed, you will not be able to use your old certificate.
 
 Current Koji admins are Mat Selmeci and Carl Edquist.
 
@@ -119,17 +119,17 @@ When you do a non-scratch build, it will build with the *osg-el6* and *osg-el7* 
 
 The most recent build results are always shown on the home page of Koji:
 
-<https://koji.chtc.wisc.edu/koji/index>
+<https://koji.opensciencegrid.org/koji/index>
 
 Clicking on a build result brings you to the build information page. A successful build will result in the build page having build logs, RPMs, and a SRPM.
 
 If your build isn't in the recent list, you can use the search box in the upper-right-hand corner. Type the exact package name (or use a wildcard), and it will bring up a list of all builds for that package. You can find your build from there. For example, the "lcmaps" package page is here:
 
-<https://koji.chtc.wisc.edu/koji/packageinfo?packageID=56>
+<https://koji.opensciencegrid.org/koji/packageinfo?packageID=56>
 
 And the lcmaps-1.6.6-1.1.osg33.el6 build is here:
 
-<https://koji.chtc.wisc.edu/koji/buildinfo?buildID=7427>
+<https://koji.opensciencegrid.org/koji/buildinfo?buildID=7427>
 
 #### Trying our your build
 

--- a/docs/software/osg-build-tools.md
+++ b/docs/software/osg-build-tools.md
@@ -25,7 +25,7 @@ This is the primary tool used in building source and binary RPMs.
 
 ##### koji
 
-Prebuilds the final source package, then builds it remotely using the Koji instance hosted at UW-Madison. <https://koji.chtc.wisc.edu> By default, the resulting RPMs will end up in the osg-minefield repositories based on the most recent OSG major version (e.g. 3.4). You may specify a different set of repos with `--repo`, described later. RPMs from the osg-minefield repositories are regularly pulled to the osg-development repositories hosted by the GOC at <http://repo.opensciencegrid.org> Unless you specify otherwise (by passing `--el6`, `--el7` or specifying a different koji tag/target), the package will be built for both el6 and el7. This is the method used to build final versions of packages you expect to ship.
+Prebuilds the final source package, then builds it remotely using the Koji instance hosted at UW-Madison. <https://koji.opensciencegrid.org> By default, the resulting RPMs will end up in the osg-minefield repositories based on the most recent OSG major version (e.g. 3.4). You may specify a different set of repos with `--repo`, described later. RPMs from the osg-minefield repositories are regularly pulled to the osg-development repositories hosted by the GOC at <http://repo.opensciencegrid.org> Unless you specify otherwise (by passing `--el6`, `--el7` or specifying a different koji tag/target), the package will be built for both el6 and el7. This is the method used to build final versions of packages you expect to ship.
 
 ##### lint
 
@@ -204,7 +204,7 @@ Specifies the method osg-build will use to interface with Koji. This can be `she
 
 ##### --wait, --no-wait, --nowait
 
-Wait for koji tasks to finish. Bad for running multiple builds in a single command, since you will have to type in your passphrase for the first one, wait for it to complete, then type in your passphrase for the second one, wait for it to complete, etc. If you want to wait for multiple tasks to finish, use the `koji watch-task` command or look at the website <https://koji.chtc.wisc.edu>.
+Wait for koji tasks to finish. Bad for running multiple builds in a single command, since you will have to type in your passphrase for the first one, wait for it to complete, then type in your passphrase for the second one, wait for it to complete, etc. If you want to wait for multiple tasks to finish, use the `koji watch-task` command or look at the website <https://koji.opensciencegrid.org>.
 
 `--wait` used to be the default until `osg-build-1.1.3`
 
@@ -373,7 +373,7 @@ Run `osg-build prepare <PACKAGEDIR>`. Look inside the `_build_results` directory
 
 -   If you have all the build dependencies of the package installed, run `osg-build rpmbuild <PACKAGEDIR>`. The resulting RPMs will be in the `_build_results` directory.
 -   If you do not have all the build dependencies installed, or want to make sure you specified all of the necessary ones and the package builds from a clean environment, run `osg-build mock --mock-config-from-koji osg-3.4-el6-build <PACKAGEDIR>`. The resulting RPMs will be in the `_build_results` directory.
--   If you do not have mock installed, or want to exactly replicate the build environment in Koji, run `osg-build koji --scratch <PACKAGEDIR>`. You may download the resulting RPMs from kojiweb <https://koji.chtc.wisc.edu/koji> or pass `--getfiles` to `osg-build koji` and they will get downloaded to the `_build_results` directory.
+-   If you do not have mock installed, or want to exactly replicate the build environment in Koji, run `osg-build koji --scratch <PACKAGEDIR>`. You may download the resulting RPMs from kojiweb <https://koji.opensciencegrid.org/koji> or pass `--getfiles` to `osg-build koji` and they will get downloaded to the `_build_results` directory.
 
 #### Check for potential errors in a package
 
@@ -383,7 +383,7 @@ Run `osg-build lint <PACKAGEDIR>`.
 
 1.  `svn commit` your changes in `branches/upcoming`.
 2.  Type `osg-build koji --repo=upcoming <PACKAGEDIR>`
-3.  Wait for the `osg-upcoming-minefield` repos to be regenerated containing the new version of your package. You can run `osg-koji wait-repo osg-upcoming-el<X>-development --build=<PACKAGENAME-VERSION-RELEASE>` and wait for that process to finish (substitute `6` or `7` for *X*). Or, you can just check kojiweb <https://koji.chtc.wisc.edu/koji/tasks>.
+3.  Wait for the `osg-upcoming-minefield` repos to be regenerated containing the new version of your package. You can run `osg-koji wait-repo osg-upcoming-el<X>-development --build=<PACKAGENAME-VERSION-RELEASE>` and wait for that process to finish (substitute `6` or `7` for *X*). Or, you can just check kojiweb <https://koji.opensciencegrid.org/koji/tasks>.
 4.  On your test machine, make sure the `osg-upcoming-minefield` repo is enabled (edit `/etc/yum.repos.d/osg-upcoming-minefield.repo` or `/etc/yum.repos.d/osg-el6-upcoming-minefield.repo`). Clean your cache (`yum clean all; yum clean expire-cache`).
 5.  Install your software, see if it works.
 

--- a/docs/software/repository-management.md
+++ b/docs/software/repository-management.md
@@ -21,18 +21,18 @@ These repos are updated by the `mash` script running on `repo.opensciencegrid.or
 Internal repositories
 ---------------------
 
-In addition to the public repositories above, we host two repositories on `koji.chtc.wisc.edu`. These are updated shortly after jobs are built into them or tagged into them. They are technically publicly accessible, but we discourage the public from using them.
+In addition to the public repositories above, we host two repositories on `koji.opensciencegrid.org`. These are updated shortly after jobs are built into them or tagged into them. They are technically publicly accessible, but we discourage the public from using them.
 
 -   **minefield**: This repository is a copy of development above.
 
 -   **prerelease**: This repository is a staging area for software that is slated to be in the next release.
 
-These repos are updated by the `kojira` daemon running on `koji.chtc.wisc.edu`.
+These repos are updated by the `kojira` daemon running on `koji.opensciencegrid.org`.
 
 Build repositories
 ------------------
 
-The `koji` task in `osg-build` uses the [osg-3.4-el6-build](http://koji.chtc.wisc.edu/koji/taginfo?tagID=472)/[osg-3.4-el7-build](http://koji.chtc.wisc.edu/koji/taginfo?tagID=481) repo, which is the union of the following repositories:
+The `koji` task in `osg-build` uses the [osg-3.4-el6-build](http://koji.opensciencegrid.org/koji/taginfo?tagID=472)/[osg-3.4-el7-build](http://koji.opensciencegrid.org/koji/taginfo?tagID=481) repo, which is the union of the following repositories:
 
 -   Minefield a.k.a. `osg-3.4-el6-development` / `osg-3.4-el7-development`
 -   The `osg-el6-internal` / `osg-el7-internal` tag (containing build dependencies we do not want to make public)
@@ -41,7 +41,7 @@ The `koji` task in `osg-build` uses the [osg-3.4-el6-build](http://koji.chtc.wis
 
 Koji will work from its internal cache of the above repositories (downloading the packages from the source), and will not update until the build repository is regenerated. By default, Koji does a groupinstall of the build group, then resolves the BuildRequires dependencies.
 
-The tarball creation scripts use the [osg-3.4-el6-release-build](https://koji.chtc.wisc.edu/koji/taginfo?tagID=478) / [osg-3.4-el7-release-build](https://koji.chtc.wisc.edu/koji/taginfo?tagID=487) repo, which is the union of the following repositories:
+The tarball creation scripts use the [osg-3.4-el6-release-build](https://koji.opensciencegrid.org/koji/taginfo?tagID=478) / [osg-3.4-el7-release-build](https://koji.opensciencegrid.org/koji/taginfo?tagID=487) repo, which is the union of the following repositories:
 
 -   Release a.k.a. `osg-3.4-el6-release` / `osg-3.4-el7-release`
 -   The `dist-el6-build` / `dist-el7-build` tag (consisting of the appropriate macros for `%dist`)


### PR DESCRIPTION
I left a few docs (e.g. the globus mass rebuild doc) alone because those docs
are super outdated and we might just want to get rid of them.

[SOFTWARE-3624]

[SOFTWARE-3624]: https://opensciencegrid.atlassian.net/browse/SOFTWARE-3624