### PR TITLE
updating service now fermilab links (SOFTWARE-4130)

### DIFF
--- a/docs/software/new-team-member.md
+++ b/docs/software/new-team-member.md
@@ -2,7 +2,7 @@ Setup Instructions for New Team Members
 =======================================
 
 1. Computing account at FNAL
-    -   To get this, follow the instructions at <https://fermi.service-now.com/kb_view.do?sysparm_article=KB0010797>
+    -   To get this, follow the instructions [here](https://fermi.servicenowservices.com/kb_view.do?sysparm_article=KB0010797).
 1. ssh access to a UW CompSci account, including AFS access
     - Send email to Tim C with top 3 requested usernames
 1. Read/write access to the UW Subversion repository;


### PR DESCRIPTION
I ran a:

```console
grep -wR 'service-now' *
docs/software/new-team-member.md:    -   To get this, follow the instructions at <https://fermi.service-now.com/kb_view.do?sysparm_article=KB0010797>
```

and this was the only hit.

[SOFTWARE-4130](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4130)