### PR TITLE
Fix CI failures for new pages (SOFTWARE-4343)

### DIFF
--- a/.github/workflows/validate-mkdocs.yml
+++ b/.github/workflows/validate-mkdocs.yml
@@ -14,14 +14,20 @@ jobs:
             build
             --verbose
             --strict
+
+      - id: format-github-repo
+        run: echo "::set-output name=repo-name::${GITHUB_REPOSITORY#*\/}"
+
       - name: Test links
         timeout-minutes: 10
         uses: docker://klakegg/html-proofer:3.16.0
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           args: >-
             --allow-hash-href
             --check-html
             --http-status-ignore 302
             --file-ignore ./site/404.html
-            --url-ignore "https://fonts.gstatic.com,/github.com\/opensciencegrid\/${GITHUB_REPOSITORY#*\/}\/edit/,/opensciencegrid.org\/${GITHUB_REPOSITORY#*\/}/"
+            --url-ignore "https://fonts.gstatic.com,/github.com\/opensciencegrid\/${{ steps.format-github-repo.outputs.repo-name }}\/edit/,/opensciencegrid.org\/${{ steps.format-github-repo.outputs.repo-name }}/"
             ./site


### PR DESCRIPTION
This worked in a previous run where I added a dummy `foo.md`: https://github.com/opensciencegrid/technology/runs/1818652318?check_suite_focus=true#step:5:40