### PR TITLE
update OASIS SLA url

### DIFF
--- a/docs/policy/external-oasis-repos.md
+++ b/docs/policy/external-oasis-repos.md
@@ -27,7 +27,7 @@ for use of the software in external repositories, but will help end-users contac
 OSG Responsibilities
 ---------------------
 
-* OSG will provide the Stratum-1 server network according to [the OASIS SLA](https://www.opensciencegrid.org/operations/SLA/oasis-replica/)
+* OSG will provide the Stratum-1 server network according to [the OASIS SLA](https://www.opensciencegrid.org/operations/SLA/oasis/)
 * OSG will provide a best-effort mirror of the full contents of the external repo.  We will attempt to provide best-effort integrity of the
   object contents, but assume users of the Stratum-1 will do further integrity checking.  No SLA is provided covering potential data corruptions.
 * OSG will provide best-effort notification to the mirrored repository in case OSG detects a service outage of the external repo.


### PR DESCRIPTION
As a part of my SLA update activities, I found this doc referencing an old one for oasis-replica that we will remove. The current up-to-date SLA covers it (Oasis Stratum 1) rather than having it in a separate doc https://opensciencegrid.org/operations/SLA/oasis/ 