### PR TITLE
Use WLCG style scopes when requesting WLCG tokens

### DIFF
--- a/docs/software/requesting-tokens.md
+++ b/docs/software/requesting-tokens.md
@@ -39,8 +39,8 @@ Requesting Tokens
 
         | **Capability**   | **Scope**                     |
         |------------------|-------------------------------|
-        | HTCondor `READ`  | `condor:/READ`                |
-        | HTCondor `WRITE` | `condor:/WRITE`               |
+        | HTCondor `READ`  | `compute.read`                |
+        | HTCondor `WRITE` | `compute.modify compute.cancel compute.create` |
         | XRootD read      | `read:/`                      |
         | XRootD write     | `write:/`                     |
 


### PR DESCRIPTION
Not sure if we just need one of these scopes or all of them for the `condor:/WRITE` equivalent