### PR TITLE
Add link to the topology registration info on the operations site

### DIFF
--- a/docs/policy/topology-registration.md
+++ b/docs/policy/topology-registration.md
@@ -1,0 +1,5 @@
+Handling Topology and Contacts Registration
+===========================================
+
+This is an internal procedure handled by OSG Staff;
+the documentation is available in the [operations site](https://opensciencegrid.org/operations/services/topology-contacts-data/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - 'Community Testing': 'policy/community-testing.md'
     - Registering with the OSG: 'policy/comanage-instructions-user.md'
     - Approving COManage Registrations: 'policy/comanage-instructions-admin.md'
+    - Handling Topology/Contacts Registrations: 'policy/topology-registration.md'
   - Documentation:
     - Writing Documentation: 'documentation/writing-documentation.md'
     - Reviewing Documentation: 'documentation/reviewing-documentation.md'


### PR DESCRIPTION
This one was fairly hard to find; even though it's an operation task, it's something that's only handled by OSG Software people who are unlikely to search through the operations docs (or even find the operations docs).
