### PR TITLE
Update Docker osg-wn release instructions (SOFTWARE-4812)

### DIFF
--- a/docs/release/cut-data-release.md
+++ b/docs/release/cut-data-release.md
@@ -228,18 +228,27 @@ find /p/vdt/workspace/tarball-client -maxdepth 1 -mtime +60 -name 3\* -exec rm -
 
 ### Step 7: Update the Docker WN client
 
-Update the GitHub repo at [opensciencegrid/docker-osg-wn](https://github.com/opensciencegrid/docker-osg-wn) using the `update-all` script found in [opensciencegrid/docker-osg-wn-scripts](https://github.com/opensciencegrid/docker-osg-wn-scripts). This requires push access to the `opensciencegrid/docker-osg-wn` repo.
+Update the GitHub repo at [opensciencegrid/docker-osg-wn](https://github.com/opensciencegrid/docker-osg-wn) using the
+`update-all` script found in
+[opensciencegrid/docker-osg-wn-scripts](https://github.com/opensciencegrid/docker-osg-wn-scripts).
+This requires push access to the `opensciencegrid/docker-osg-wn` repo and access to `dumbo.chtc.wisc.edu`.
 
-Instructions for using the script:
+1.  SSH into `dumbo.chtc.wisc.edu`
 
-```bash
-git clone git@github.com:opensciencegrid/docker-osg-wn-scripts.git
-git clone git@github.com:opensciencegrid/docker-osg-wn.git
-docker-osg-wn-scripts/update-all docker-osg-wn
-cd docker-osg-wn
-# Verify everything looks fine and run the 'git push' command
-# that 'update-all' should have printed
-```
+1.  Clone the necessary repositories:
+
+        git clone git@github.com:opensciencegrid/docker-osg-wn-scripts.git
+        git clone git@github.com:opensciencegrid/docker-osg-wn.git
+
+1.  Build and push the images:
+
+        docker-osg-wn-scripts/update-all docker-osg-wn
+
+1.  Check that everything is ok and update the `docker-osg-wn` branches using the `git push` command that the
+    `update-all` script should have printed:
+
+        cd docker-osg-wn
+        git push ...
 
 ### Step 8: Rebuild the Docker software base
 

--- a/docs/release/cut-data-release.md
+++ b/docs/release/cut-data-release.md
@@ -228,6 +228,10 @@ find /p/vdt/workspace/tarball-client -maxdepth 1 -mtime +60 -name 3\* -exec rm -
 
 ### Step 7: Update the Docker WN client
 
+!!! warning "Lengthy build time"
+    Until we resolve [SOFTWARE-4692](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4692), the scripts have been
+    updated to build each image on the local host and push directly to Docker Hub so this process can take over an hour.
+
 Update the GitHub repo at [opensciencegrid/docker-osg-wn](https://github.com/opensciencegrid/docker-osg-wn) using the
 `update-all` script found in
 [opensciencegrid/docker-osg-wn-scripts](https://github.com/opensciencegrid/docker-osg-wn-scripts).
@@ -239,6 +243,10 @@ This requires push access to the `opensciencegrid/docker-osg-wn` repo and access
 
         git clone git@github.com:opensciencegrid/docker-osg-wn-scripts.git
         git clone git@github.com:opensciencegrid/docker-osg-wn.git
+
+1.  Enter your Docker Hub user name and password to be able to directly push images:
+
+        docker login
 
 1.  Build and push the images:
 

--- a/docs/release/cut-sw-release.md
+++ b/docs/release/cut-sw-release.md
@@ -223,18 +223,27 @@ find /p/vdt/workspace/tarball-client -maxdepth 1 -mtime +60 -name 3\* -exec rm -
 
 ### Step 7: Update the Docker WN client
 
-Update the GitHub repo at [opensciencegrid/docker-osg-wn](https://github.com/opensciencegrid/docker-osg-wn) using the `update-all` script found in [opensciencegrid/docker-osg-wn-scripts](https://github.com/opensciencegrid/docker-osg-wn-scripts). This requires push access to the `opensciencegrid/docker-osg-wn` repo.
+Update the GitHub repo at [opensciencegrid/docker-osg-wn](https://github.com/opensciencegrid/docker-osg-wn) using the
+`update-all` script found in
+[opensciencegrid/docker-osg-wn-scripts](https://github.com/opensciencegrid/docker-osg-wn-scripts).
+This requires push access to the `opensciencegrid/docker-osg-wn` repo and access to `dumbo.chtc.wisc.edu`.
 
-Instructions for using the script:
+1.  SSH into `dumbo.chtc.wisc.edu`
 
-```bash
-git clone git@github.com:opensciencegrid/docker-osg-wn-scripts.git
-git clone git@github.com:opensciencegrid/docker-osg-wn.git
-docker-osg-wn-scripts/update-all docker-osg-wn
-cd docker-osg-wn
-# Verify everything looks fine and run the 'git push' command
-# that 'update-all' should have printed
-```
+1.  Clone the necessary repositories:
+
+        git clone git@github.com:opensciencegrid/docker-osg-wn-scripts.git
+        git clone git@github.com:opensciencegrid/docker-osg-wn.git
+
+1.  Build and push the images:
+
+        docker-osg-wn-scripts/update-all docker-osg-wn
+
+1.  Check that everything is ok and update the `docker-osg-wn` branches using the `git push` command that the
+    `update-all` script should have printed:
+
+        cd docker-osg-wn
+        git push ...
 
 ### Step 8: Rebuild the Docker software base
 

--- a/docs/release/cut-sw-release.md
+++ b/docs/release/cut-sw-release.md
@@ -223,6 +223,10 @@ find /p/vdt/workspace/tarball-client -maxdepth 1 -mtime +60 -name 3\* -exec rm -
 
 ### Step 7: Update the Docker WN client
 
+!!! warning "Lengthy build time"
+    Until we resolve [SOFTWARE-4692](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4692), the scripts have been
+    updated to build each image on the local host and push directly to Docker Hub so this process can take over an hour.
+
 Update the GitHub repo at [opensciencegrid/docker-osg-wn](https://github.com/opensciencegrid/docker-osg-wn) using the
 `update-all` script found in
 [opensciencegrid/docker-osg-wn-scripts](https://github.com/opensciencegrid/docker-osg-wn-scripts).
@@ -234,6 +238,10 @@ This requires push access to the `opensciencegrid/docker-osg-wn` repo and access
 
         git clone git@github.com:opensciencegrid/docker-osg-wn-scripts.git
         git clone git@github.com:opensciencegrid/docker-osg-wn.git
+
+1.  Enter your Docker Hub user name and password to be able to directly push images:
+
+        docker login
 
 1.  Build and push the images:
 


### PR DESCRIPTION
We'll need to do it this way until we finish
https://opensciencegrid.atlassian.net/browse/SOFTWARE-4692

To go along with https://github.com/opensciencegrid/docker-osg-wn-scripts/pull/13