### PR TITLE
WLCG scopes: modify, not write

### DIFF
--- a/docs/software/requesting-tokens.md
+++ b/docs/software/requesting-tokens.md
@@ -45,7 +45,7 @@ and refresh tokens from OpenID Connect token providers.
         | HTCondor `READ`  | `compute.read`                |
         | HTCondor `WRITE` | `compute.modify compute.cancel compute.create` |
         | XRootD read      | `storage.read:/`                               |
-        | XRootD write     | `storage.write:/`                              |
+        | XRootD write     | `storage.modify:/`                             |
 
         For example, to request HTCondor `READ` and `WRITE` access, specify the following scopes:
 


### PR DESCRIPTION
WLCG differntiates between "modify" and "create"